### PR TITLE
Update express listener port

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const app = express()
-const port = 3000
+const port = 8080
 
 app.get('/', (req, res) => {
   res.send('Hello World!')


### PR DESCRIPTION
The default service.yml manifest created by Azure Pipelines does not set the target port, so by default the service will target the same port as the service port. In the Microsoft docs example this is implied to be 8080 based on the instructions to connect to <IPAddress>:8080 so the express app needs to listen on this port for the guide to work.